### PR TITLE
Activate cmake policy CMP0042 to use rpaths on MacOSX (#6).

### DIFF
--- a/cnpy/CMakeLists.txt
+++ b/cnpy/CMakeLists.txt
@@ -1,13 +1,14 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.6 FATAL_ERROR)
 if(COMMAND cmake_policy)
 	cmake_policy(SET CMP0003 NEW)
+    cmake_policy(SET CMP0042 NEW)
 endif(COMMAND cmake_policy)
 
 project(CNPY)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
-option(ENABLE_STATIC "Build static (.a) library" ON)
+option(ENABLE_STATIC "Build static (.a) library" OFF)
 
 add_library(cnpy SHARED "cnpy.cpp")
 target_link_libraries(cnpy z)


### PR DESCRIPTION
I also turned off generation of a static cnpy library as it isn't necessary when building npy4th; if you want to leave that enabled, let me know and I can update the PR.
