### PR TITLE
Added the ability to append to existing numpy files

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -30,4 +30,8 @@ tbl = npy4th.loadnpz('table.npz')
 -- save a torch.*Tensor into a .npy file
 myTensor = torch.Tensor({1,2,3})
 npy4th.savenpy('tensor.npy', myTensor)
+
+-- append a torch.*Tensor to an existing .npy file
+myTensor2 = torch.Tensor({4,5,6})
+npy4th.savenpy('tensor.npy', myTensor2, 'a')
 ```

--- a/init.lua
+++ b/init.lua
@@ -43,7 +43,7 @@ npy4th.loadnpz = function(filepath)
                    return libnpy4th.loadnpz(filepath)
                 end
 
-npy4th.savenpy = function(filepath, tensor)
+npy4th.savenpy = function(filepath, tensor, mode)
 		  if not filepath then
 			xlua.error('file path must be supplied', 
 					'npy4th.savenpy', 
@@ -56,7 +56,9 @@ npy4th.savenpy = function(filepath, tensor)
 			tensor = tensor:float() -- convert it to float
 		  end
 
-		  return libnpy4th.savenpy(filepath, tensor, typeIds[tensor:type()])
+          mode = mode or 'w'
+
+		  return libnpy4th.savenpy(filepath, tensor, typeIds[tensor:type()], mode)
 		end
 
 return npy4th

--- a/npy4th.cpp
+++ b/npy4th.cpp
@@ -89,7 +89,7 @@ static int loadnpy_l(lua_State *L) {
 		cnpy::NpyArray arr = cnpy::npy_load(fpath);
 
 		load_array_to_lua(L, arr);
-	
+
 	} catch (std::exception& e){
 		THError(e.what());
 	}
@@ -143,25 +143,28 @@ static int savenpy_l(lua_State *L){
 		const char *inType = luaT_typename(L, 2);
 
 		int typeId = luaL_checkinteger(L, 3);
+
+        const char *mode = lua_tostring(L, 4);
+
 		bool success=false;
 		switch ( typeId ){
 		case 0: //double
 		{	THDoubleTensor * tensor = (THDoubleTensor *) luaT_checkudata(L, 2, inType);
 			std::vector<size_t> shape = get_shape(tensor->nDimension, tensor->size);
-			success=cnpy::npy_save<double>(fpath, tensor->storage->data, shape, "w");
+			success=cnpy::npy_save<double>(fpath, tensor->storage->data, shape, mode);
 		} break;
 	
 		case 1: //float
 		{	THFloatTensor * tensor = (THFloatTensor *) luaT_checkudata(L, 2, inType);
 			std::vector<size_t> shape = get_shape(tensor->nDimension, tensor->size);
-			success=cnpy::npy_save<float>(fpath, tensor->storage->data, shape, "w");
+			success=cnpy::npy_save<float>(fpath, tensor->storage->data, shape, mode);
 		} 
 		break;
 	
 		case 2: //int
 		{	THIntTensor * tensor = (THIntTensor *) luaT_checkudata(L, 2, inType);
 			std::vector<size_t> shape = get_shape(tensor->nDimension, tensor->size);
-			success=cnpy::npy_save<int>(fpath, tensor->storage->data, shape, "w");
+			success=cnpy::npy_save<int>(fpath, tensor->storage->data, shape, mode);
 		} 
 		break;
 
@@ -169,21 +172,21 @@ static int savenpy_l(lua_State *L){
 		case 3: //byte
 		{	THByteTensor * tensor = (THByteTensor *) luaT_checkudata(L, 2, inType);
 			std::vector<size_t> shape = get_shape(tensor->nDimension, tensor->size);
-			success=cnpy::npy_save<unsigned char>(fpath, tensor->storage->data, shape, "w");
+			success=cnpy::npy_save<unsigned char>(fpath, tensor->storage->data, shape, mode);
 		} 
 		break;
 
 		case 4: //long
 		{	THLongTensor * tensor = (THLongTensor *) luaT_checkudata(L, 2, inType);
 			std::vector<size_t> shape = get_shape(tensor->nDimension, tensor->size);
-			success=cnpy::npy_save<long>(fpath, tensor->storage->data, shape, "w");
+			success=cnpy::npy_save<long>(fpath, tensor->storage->data, shape, mode);
 		} 
 		break;
 
 		case 5: //short
 		{	THShortTensor * tensor = (THShortTensor *) luaT_checkudata(L, 2, inType);
 			std::vector<size_t> shape = get_shape(tensor->nDimension, tensor->size);
-			success=cnpy::npy_save<short>(fpath, tensor->storage->data, shape, "w");
+			success=cnpy::npy_save<short>(fpath, tensor->storage->data, shape, mode);
 		} 
 		break;
 


### PR DESCRIPTION
The cnpy implementation already had support for appending a tensor to an existing npy file, and this change allows torch users to take advantage of it by adding an option `mode` third argument to the `.savenpy` function. It defaults to 'w' to preserve backwards compatibility. 