### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/cnpy/CMakeLists.txt
+++ b/cnpy/CMakeLists.txt
@@ -1,7 +1,9 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.6 FATAL_ERROR)
 if(COMMAND cmake_policy)
-	cmake_policy(SET CMP0003 NEW)
-    cmake_policy(SET CMP0042 NEW)
+    cmake_policy(SET CMP0003 NEW)
+    if(POLICY CMP0042)
+        cmake_policy(SET CMP0042 NEW)
+    endif(POLICY CMP0042)
 endif(COMMAND cmake_policy)
 
 project(CNPY)


### PR DESCRIPTION
Building from source was failing for me on Ubuntu 14.04 with CMake 2.8.12.2 (version from apt-get) because this version of CMake did not have CMP0042, which was introduced in CMake 3.0.

Adding the conditional fixed the issue for me.

Solution was inspired by https://github.com/slembcke/Chipmunk2D/issues/112.